### PR TITLE
Allow externals -- POC for #114

### DIFF
--- a/packages/core/parcel-bundler/src/Bundler.js
+++ b/packages/core/parcel-bundler/src/Bundler.js
@@ -202,6 +202,10 @@ class Bundler extends EventEmitter {
 
     try {
       let deps = Object.assign({}, pkg.dependencies, pkg.devDependencies);
+
+      // peer dependencies are external
+      this.externals = Object.keys(pkg.peerDependencies || {});
+
       for (let dep in deps) {
         const pattern = /^(@.*\/)?parcel-plugin-.+/;
         if (pattern.test(dep)) {
@@ -566,6 +570,14 @@ class Bundler extends EventEmitter {
 
     // Call the delegate to get implicit dependencies
     let dependencies = processed.dependencies;
+
+    // exlucde externals
+    if (this.externals.length && !this.options.hmr) {
+      dependencies.forEach((dep, i) => {
+        if (this.externals.includes(dep.name)) dependencies.splice(i, 1);
+      });
+    }
+
     if (this.delegate.getImplicitDependencies) {
       let implicitDeps = await this.delegate.getImplicitDependencies(asset);
       if (implicitDeps) {


### PR DESCRIPTION
<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting since someone might have pushed the same thing before!
-->

# ↪️ Pull Request

Does not bundles modules in package.json's `peerDependencies`.


## 💻 Examples
package.json:
```
  "peerDependencies": {
    "prop-types": "^15.6.2",
    "react": "^16.7.0",
    "react-dom": "^16.7.0",
    "react-intl": "^2.8.0"
  },
```
Then:
```
$ npm run build  # parcel build

dist/foo-bar.js                                                                             38.47 KB    96ms
├── node_modules/react-idle-timer/dist/index.es.js           6.46 KB     1ms
├── src/sessionTimeout/index.js                                           3.68 KB     3ms
...
```
Notice no `react`, `react-dom`, etc. in the final build.

`parcel start` (HMR) will still pull those modules in.

## 🚨 Test instructions

<!-- In case it is impossible (or too hard) to reliably test this feature/fix with unit tests, please provide test instructions! -->

## ✔️ PR Todo

- [ ] Added/updated unit tests for this change
- [ ] Filled out test instructions (In case there aren't any unit tests)
- [ ] Included links to related issues/PRs

<!--
Love parcel? Please consider supporting our collective:
👉  https://opencollective.com/parcel/donate
-->
